### PR TITLE
syscall: bpfloader: Fake uname to 6.6.40

### DIFF
--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -1248,12 +1248,20 @@ static int override_release(char __user *release, size_t len)
 	return ret;
 }
 
+static uint64_t netbpfload_pid = 0;
 SYSCALL_DEFINE1(newuname, struct new_utsname __user *, name)
 {
 	struct new_utsname tmp;
 
 	down_read(&uts_sem);
 	memcpy(&tmp, utsname(), sizeof(tmp));
+	if (!strncmp(current->comm, "netbpfload", 10) &&
+	    current->pid != netbpfload_pid) {
+		netbpfload_pid = current->pid;
+		strcpy(tmp.release, "6.6.40");
+		pr_debug("fake uname: %s/%d release=%s\n",
+			 current->comm, current->pid, tmp.release);
+	}
 	up_read(&uts_sem);
 	if (copy_to_user(name, &tmp, sizeof(tmp)))
 		return -EFAULT;


### PR DESCRIPTION
It seems Google slowly killing old kernel, and this happened on 4.14, maybe 4.19 soon?
(https://android.googlesource.com/platform/system/bpf/+/0156d6e2ba1e90eecbd9ef47bcb39c41dcc78e53)
and then, this commit exist

This commit includes:
- Fake uname for bpfloader/netd and netbpfload
- Only fake uname on very first call of netbpfload